### PR TITLE
Fixed players get unregistered twice on kick

### DIFF
--- a/src/_64FF00/PurePerms/PPListener.php
+++ b/src/_64FF00/PurePerms/PPListener.php
@@ -69,17 +69,6 @@ class PPListener implements Listener
     }
 
     /**
-     * @param PlayerKickEvent $event
-     * @priority HIGHEST
-     */
-    public function onPlayerKick(PlayerKickEvent $event)
-    {
-        $player = $event->getPlayer();
-
-        $this->plugin->unregisterPlayer($player);
-    }
-
-    /**
      * @param PlayerQuitEvent $event
      * @priority HIGHEST
      */


### PR DESCRIPTION
When a player is kicked, both PlayerQuitEvent and PlayerKickEvent are fired, and because of this a player got "unregisterd" two times every time he would get kicked