### PR TITLE
Prevent restrictions from being inherited

### DIFF
--- a/src/_64FF00/PurePerms/PPGroup.php
+++ b/src/_64FF00/PurePerms/PPGroup.php
@@ -100,9 +100,19 @@ class PPGroup
         {
             $inheritedGroupPermissions = $inheritedGroup->getGroupPermissions($levelName);
             
-            if($inheritedGroupPermissions === null) $inheritedGroupPermissions = [];
+            //if($inheritedGroupPermissions === null) $inheritedGroupPermissions = [];
             
-            $permissions = array_merge($permissions, $inheritedGroupPermissions);
+            //$permissions = array_merge($permissions, $inheritedGroupPermissions);
+            
+            // Modified by @madhon 2015-12-05 to exclude restricitions from inheritance
+            
+            if($inheritedGroupPermissions != null) {
+            	foreach($inheritedGroupPermissions as $inheritedPermission) {
+            		if($inheritedPermission[0] != '-' && !in_array($inheritedPermission, $permissions) {
+            			$permissions[] = $inheritedPermission;
+            		}
+            	}
+            }
         }
         
         return $permissions;


### PR DESCRIPTION
The original code inherits all permissions, including restrictions (permissions beginning with "-") from inherited groups.

This modification changes it to omit restrictions from inherited permissions.
It also prevents duplication of permissions that are manually set for multiple inherited groups.
Use case: server owner does not have access to config files (such as with Leet Realms) but wants to restrict Guest's access to a features that's enabled by default.